### PR TITLE
feat: 컬렉션 id 암복호화 적용

### DIFF
--- a/src/collection/collection.crypto.ts
+++ b/src/collection/collection.crypto.ts
@@ -1,14 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createCipheriv, createDecipheriv } from 'crypto';
+import { WrongEncryptedText } from 'src/common/exception/service.exception';
 
 @Injectable()
 export class Encrypt {
   constructor(private readonly configService: ConfigService) {}
 
   private readonly crypto = require('crypto');
-  private readonly iv = this.crypto.randomBytes(16);
   private readonly password = this.configService.get('JWT_SECRET');
+  private readonly iv = this.configService
+    .get('JWT_REFRESH_SECRET')
+    .substring(0, 16);
   private readonly salt = this.configService.get('CRYPTO_SALT');
   // The key length is dependent on the algorithm.
   // In this case for aes256, it is 32 bytes.
@@ -30,12 +33,20 @@ export class Encrypt {
   }
 
   decrypt(encryptedText: string) {
-    const decipher = createDecipheriv(this.algorithm, this.key, this.iv);
-    const decryptedText = Buffer.concat([
-      decipher.update(Buffer.from(encryptedText, 'base64')),
-      decipher.final(),
-    ]);
+    try {
+      const decipher = createDecipheriv(this.algorithm, this.key, this.iv);
+      const decryptedText = Buffer.concat([
+        decipher.update(Buffer.from(encryptedText, 'base64')),
+        decipher.final(),
+      ]);
 
-    return decryptedText;
+      return decryptedText;
+    } catch (error) {
+      if (error.code == 'ERR_OSSL_BAD_DECRYPT') {
+        throw WrongEncryptedText();
+      } else {
+        throw error;
+      }
+    }
   }
 }

--- a/src/collection/dto/collection-list.dto.ts
+++ b/src/collection/dto/collection-list.dto.ts
@@ -1,0 +1,24 @@
+import { Collection } from '../entities/collection.entity';
+
+export class CollectionListResponseDto {
+  id: number;
+  title: string;
+  note: string;
+  shared_id: string;
+  created_at: Date;
+  updated_at: Date;
+
+  static of(
+    collection: Collection,
+    encryptedText: string,
+  ): CollectionListResponseDto {
+    return {
+      id: collection.id,
+      title: collection.title,
+      note: collection.note,
+      shared_id: encryptedText,
+      created_at: collection.created_at,
+      updated_at: collection.updated_at,
+    };
+  }
+}

--- a/src/collection/dto/find-collection.dto.ts
+++ b/src/collection/dto/find-collection.dto.ts
@@ -1,15 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber } from 'class-validator';
+import { IsString } from 'class-validator';
 import { Type } from 'class-transformer';
 import { FindAllCollectionDto } from './find-all-collection.dto';
 
 export class FindCollectionDto extends FindAllCollectionDto {
   @ApiProperty({
-    description: 'collection id',
-    example: '1',
+    description: '암호화된 collection id = shared_id',
+    example: 'asdfdsf==',
     required: true,
   })
-  @IsNumber()
-  @Type(() => Number)
-  id: number;
+  @IsString()
+  @Type(() => String)
+  id: string;
 }

--- a/src/common/exception/service.exception.ts
+++ b/src/common/exception/service.exception.ts
@@ -4,6 +4,7 @@ import {
   UNABLE_DELETE_MERGED_DATA,
   TOO_MANY_COLLECTION,
   TOO_MANY_COLLECTION_ITEM,
+  WRONG_ENCRYPTEDTEXT,
 } from '../interface/error-code.type';
 
 export const UnableDeleteMergedDataException = (): ServiceException => {
@@ -20,6 +21,10 @@ export const TooManyCollectionException = (): ServiceException => {
 
 export const TooManyCollectionItemException = (): ServiceException => {
   return new ServiceException(TOO_MANY_COLLECTION_ITEM);
+};
+
+export const WrongEncryptedText = (): ServiceException => {
+  return new ServiceException(WRONG_ENCRYPTEDTEXT);
 };
 
 export class ServiceException extends Error {

--- a/src/common/interface/error-code.type.ts
+++ b/src/common/interface/error-code.type.ts
@@ -37,3 +37,9 @@ export const TOO_MANY_COLLECTION_ITEM = new ErrorCodeVo(
   HttpStatus.FORBIDDEN,
   '컬렉션 아이템은 최대 500개까지만 추가할 수 있습니다.',
 );
+
+export const WRONG_ENCRYPTEDTEXT = new ErrorCodeVo(
+  'bad decrypt',
+  HttpStatus.BAD_REQUEST,
+  '조회 아이디를 확인해 주세요.',
+);


### PR DESCRIPTION
- 전체 컬렉션 조회시 암호화된 컬렉션 아이디도 함께 반환
- 단일 컬렉션 조회는 암호화된 아이디를 이용
- 암호화 IV값 고정된 값으로 수정
  - 랜덤한 값을 주었을 때, 복호화할 때 제대로 이루어지지 않음
  - DB에 암호화된 아이디 값을 따로 저장하지 않기때문에 IV값이 변경되고 나면 변경 전 암호화문을 확인할 방법이 없음
 