### PR TITLE
refactor: 아이템 삭제로직 수정

### DIFF
--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -301,11 +301,15 @@ export class CollectionService {
     try {
       const deletId: number[] = [];
       for (const dto of deleteCollectionItemDto) {
-        await this.collectionItemRepository.findOneOrFail({
-          where: { id: dto.collection_item_id },
-        });
+        const collection_item =
+          await this.collectionItemRepository.findOneOrFail({
+            where: {
+              collection: { id: collection_id },
+              wata: { id: dto.wata_id },
+            },
+          });
 
-        deletId.push(dto.collection_item_id);
+        deletId.push(collection_item.id);
       }
 
       return this.collectionItemRepository.delete(deletId);

--- a/src/collection/dto/add-collection-item.dto.ts
+++ b/src/collection/dto/add-collection-item.dto.ts
@@ -3,14 +3,6 @@ import { Type } from 'class-transformer';
 import { IsArray, IsNumber } from 'class-validator';
 
 export class AddCollectionItemDto {
-  // @ApiProperty({
-  //   description: '컬렉션 ID',
-  //   example: '1',
-  //   required: true,
-  // })
-  // @IsNumber()
-  // collection_id: number;
-
   @ApiProperty({
     description: '와타 ID',
     example: '1',

--- a/src/collection/dto/delete-collection-item.dto.ts
+++ b/src/collection/dto/delete-collection-item.dto.ts
@@ -9,7 +9,7 @@ export class DeleteCollectionItemDto {
     required: true,
   })
   @IsNumber()
-  collection_item_id: number;
+  wata_id: number;
 }
 
 export class DeleteCollectionItemsDto {


### PR DESCRIPTION
- 기존의 삭제 DTO 변경
  - collection item ID -> wata ID
 - collection item id로 제거하는 것은 동일 
   - 이유: 컬렉션에 해당 데이터가 들어있는 확인 함 => 컬렉션 아이디를 알 수 있음, 확인하는 과정을 collection item id 에서 wata id + collection id 로 변경함