### PR TITLE
fix: genre, keywords, cautions, platforms에 핵심 정보만 저장되게 수정

### DIFF
--- a/src/publish-wata/dto/upsert-publish-wata.dto.ts
+++ b/src/publish-wata/dto/upsert-publish-wata.dto.ts
@@ -1,0 +1,49 @@
+import { PartialType } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { WataThumbnailCropAreaType } from 'src/admin/wata/interface/wata.type';
+
+export class InfoDto {
+  id: number;
+  name: string;
+}
+
+export class PlatformInfoDto extends PartialType(InfoDto) {
+  url: string;
+}
+
+export class GenreInfoDto extends PartialType(InfoDto) {
+  category: {
+    id: number;
+    name: string;
+  };
+}
+
+export class UpsertPublishWataDto {
+  id: number;
+
+  title: string;
+
+  creators: string;
+
+  thumbnail: string;
+
+  thumbnail_card?: WataThumbnailCropAreaType;
+
+  thumbnail_book?: WataThumbnailCropAreaType;
+
+  @Type(() => GenreInfoDto)
+  genre: GenreInfoDto;
+
+  @Type(() => InfoDto)
+  keywords: InfoDto[];
+
+  @Type(() => InfoDto)
+  cautions?: InfoDto[];
+
+  @Type(() => PlatformInfoDto)
+  platforms: PlatformInfoDto[];
+
+  adder?: InfoDto;
+
+  updater?: InfoDto;
+}

--- a/src/publish-wata/publish-wata.service.ts
+++ b/src/publish-wata/publish-wata.service.ts
@@ -130,26 +130,49 @@ export class PublishWataService {
 
       const updateItems = [];
 
-      for (const create of createItems) {
+      for (const createItem of createItems) {
         upsertItems.push(
           this.publishWataRepository.create({
-            id: create.id,
-            title: create.title,
-            creators: create.creators,
-            thumbnail: create.thumbnail,
-            thumbnail_card: create.thumbnail_card,
-            thumbnail_book: create.thumbnail_book,
-            genre: create.genre,
-            keywords: create.keywords,
-            cautions: create.cautions,
-            platforms: create.platforms,
-            adder: create.adder,
-            updater: create.updater,
+            id: createItem.id,
+            title: createItem.title,
+            creators: createItem.creators,
+            thumbnail: createItem.thumbnail,
+            thumbnail_card: createItem.thumbnail_card,
+            thumbnail_book: createItem.thumbnail_book,
+            genre: {
+              id: createItem.genre.id,
+              name: createItem.genre.name,
+              category: {
+                id: createItem.genre.category.id,
+                name: createItem.genre.category.name,
+              },
+            },
+            keywords: createItem.keywords?.map((keyword) => {
+              return {
+                id: keyword.keyword.id,
+                name: keyword.keyword.name,
+              };
+            }),
+            cautions: createItem.cautions?.map((caution) => {
+              return {
+                id: caution.caution.id,
+                name: caution.caution.name,
+              };
+            }),
+            platforms: createItem.platforms?.map((platform) => {
+              return {
+                id: platform.platform.id,
+                name: platform.platform.name,
+                url: platform.url,
+              };
+            }),
+            adder: createItem.adder,
+            updater: createItem.updater,
           }),
         );
-        createdItems.push(create.title);
+        createdItems.push(createItem.title);
         createdCount++;
-        updateItems.push(create.id);
+        updateItems.push(createItem.id);
       }
 
       // Iterate through each wata record


### PR DESCRIPTION
- genre, keywords, cautions, platforms 매핑 데이터 id, 날짜 등의 정보가 들어가지 않게 수정
- create, update 데이터 가공 후 published_wata DB 테이블에 저장
- published_wata 테이블에 데이터 생성시, is_published = false인 경우에만 true로 업데이트하게 수정