### PR TITLE
feat: rate limiting을 publish-wata module에 적용

### DIFF
--- a/src/publish-wata/publish-wata.module.ts
+++ b/src/publish-wata/publish-wata.module.ts
@@ -6,14 +6,28 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { KeywordsModule } from 'src/admin/keywords/keywords.module';
 import { CacheModule } from '@nestjs/cache-manager';
 import { PublishWata } from './entities/publish-wata.entity';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler'
+import { APP_GUARD } from '@nestjs/core';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Wata, PublishWata]),
     KeywordsModule,
     CacheModule.register(),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 100,
+      },
+    ]),
   ],
   controllers: [PublishWataController],
-  providers: [PublishWataService],
+  providers: [
+    PublishWataService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class PublishWataModule {}


### PR DESCRIPTION
- rate limiting : publish-wata.module 에 코드 추가
- 전역으로 적용 : publish-wata 를 비롯하여 admin 등 모든 앱의 API 요청에 적용됩니다
- 1분에 100회 제한